### PR TITLE
add js and css file to skipRenderList

### DIFF
--- a/lib/generator.js
+++ b/lib/generator.js
@@ -5,10 +5,13 @@ var template = require('./template');
 
 module.exports = function(locals) {
   var config = this.config;
-  var skipRenderList = [];
+  var skipRenderList = [
+    '**/*.js',
+    '**/*.css'
+  ];
 
   if (Array.isArray(config.skip_render)) {
-    skipRenderList = config.skip_render;
+    skipRenderList = skipRenderList.concat(config.skip_render);
   } else if (config.skip_render != null) {
     skipRenderList.push(config.skip_render);
   }


### PR DESCRIPTION
fix #16 
ignore js and css file when building sitemap globally.