### PR TITLE
refactor(package): use Object.assign instead of object-assign package

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,10 +1,9 @@
 /* global hexo */
 'use strict';
 
-var assign = require('object-assign');
 var pathFn = require('path');
 
-var config = hexo.config.sitemap = assign({
+var config = hexo.config.sitemap = Object.assign({
   path: 'sitemap.xml'
 }, hexo.config.sitemap);
 

--- a/package.json
+++ b/package.json
@@ -25,8 +25,7 @@
   "license": "MIT",
   "dependencies": {
     "minimatch": "^3.0.0",
-    "nunjucks": "^2.3.0",
-    "object-assign": "^4.0.1"
+    "nunjucks": "^2.3.0"
   },
   "devDependencies": {
     "chai": "^4.2.0",


### PR DESCRIPTION
## Proposal

Use Object.assign instead of object-assign package

## Reason

Node.js 4 and up can be use Object.assign() instead of object-assign npm package.