### PR TITLE
chore: specify files in package.json

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,8 +1,0 @@
-test/
-tmp/
-coverage/
-*.log
-.travis.yml
-gulpfile.js
-.idea/
-appveyor.yml

--- a/package.json
+++ b/package.json
@@ -11,6 +11,10 @@
   "directories": {
     "lib": "./lib"
   },
+  "files": [
+    "lib",
+    "index.js"
+  ],
   "repository": "hexojs/hexo-generator-sitemap",
   "keywords": [
     "hexo",


### PR DESCRIPTION
.npmignore is no longer necessary when using this way. This helps to reduce maintenance.

Based on https://github.com/hexojs/hexo-renderer-marked/pull/96