### PR TITLE
fix: no such file or directory error caused by sitemap.xml not includ…

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
   },
   "files": [
     "lib",
-    "index.js"
+    "index.js",
+    "sitemap.xml"
   ],
   "repository": "hexojs/hexo-generator-sitemap",
   "keywords": [


### PR DESCRIPTION
…ed package

### Why?

We specified which file includes or not in #49 and we decided includes `index.js` & `lib` directory.
But, this package must include `sitemap.xml`. If it does not include below error occurs.

```
INFO  Start processing
FATAL Something's wrong. Maybe you can find the solution here: https://hexo.io/docs/troubleshooting.html
Error: ENOENT: no such file or directory, open 'C:\Users\N.Yoshinori\site\node_modules\hexo-generator-sitemap\sitemap.xml'
    at Object.openSync (fs.js:431:3)
    at Object.readFileSync (fs.js:333:35)
    at module.exports (C:\Users\N.Yoshinori\site\_main\node_modules\hexo-generator-sitemap\lib\template.js:21:37)
    at Hexo.module.exports (C:\Users\N.Yoshinori\site\_main\node_modules\hexo-generator-sitemap\lib\generator.js:27:13)
    at Hexo.tryCatcher (C:\Users\N.Yoshinori\site\\_main\node_modules\bluebird\js\release\util.js:16:23)
    at Hexo.<anonymous> (C:\Users\N.Yoshinori\site\_main\node_modules\bluebird\js\release\method.js:15:3
```

Sorry, I made a mistake when review. this error is my fault...

@weyusi 
Would you review it?