### PR TITLE
WIP fix: use canonical url for pages

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,4 +1,7 @@
 {
   "extends": "hexo",
-  "root": true
+  "root": true,
+  "parserOptions": {
+    "ecmaVersion": 2018
+  }
 }

--- a/lib/generator.js
+++ b/lib/generator.js
@@ -22,7 +22,11 @@ module.exports = function(locals) {
     })
     .sort((a, b) => {
       return b.updated - a.updated;
-    });
+    })
+    .map((post) => ({
+      ...post,
+      permalink: post.permalink.replace(/index\.html$/, '')
+    }));
 
   const xml = template(config).render({
     config: config,


### PR DESCRIPTION
Remove `index.html` from url of pages. Fixes #13. Based on https://github.com/pyyzcwg2833/hexo-generator-sitemap/commit/a92dbbb83cc39ff60d43faa5cd688a56574a3889 (credit @pyyzcwg2833).

Added test for pages (closes https://github.com/hexojs/hexo-generator-sitemap/pull/62). Updated the `updated` attribute of hexo.init() in the test for more predictable result.

The affected code uses ES2018 feature (which is Node 8 [supports](https://node.green/#ES2018-features-object-rest-spread-properties-object-spread-properties)). Refactor everything else to ES6 should be in a separate PR.

Feel free to refactor `.concat()` and array-object-array conversion to something better.

`"ecmaVersion": 2018` can be removed once another PR https://github.com/hexojs/eslint-config-hexo/pull/16 has been released (eslint-config-hexo@4).

## Pull request tasks

- [x] Add test cases for the changes.
- [x] Passed the CI test.