### PR TITLE
fix(idn): encode url except domain (unit test need help)

### DIFF
--- a/lib/template.js
+++ b/lib/template.js
@@ -3,6 +3,7 @@
 const pathFn = require('path');
 const fs = require('fs');
 let sitemapTmpl;
+const { encodeURL } = require('hexo-util');
 
 module.exports = function(config) {
   if (sitemapTmpl) return sitemapTmpl;
@@ -14,7 +15,7 @@ module.exports = function(config) {
   });
 
   env.addFilter('uriencode', str => {
-    return encodeURI(str);
+    return encodeURL(str);
   });
 
   const sitemapSrc = config.sitemap.template || pathFn.join(__dirname, '../sitemap.xml');

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   ],
   "license": "MIT",
   "dependencies": {
+    "hexo-util": "^1.1.0",
     "micromatch": "^4.0.2",
     "nunjucks": "^3.1.6"
   },

--- a/test/index.js
+++ b/test/index.js
@@ -1,18 +1,65 @@
 'use strict';
 
-const should = require('chai').should(); // eslint-disable-line
 const Hexo = require('hexo');
+const should = require('chai').should(); // eslint-disable-line
 const cheerio = require('cheerio');
+const { encodeURL } = require('hexo-util');
 
-describe('Sitemap generator', () => {
+const ctx = {
+  config: {
+    sitemap: {
+      path: 'sitemap.xml'
+    }
+  }
+};
+
+const generator = require('../lib/generator').bind(ctx);
+
+describe('generator', () => {
   const hexo = new Hexo(__dirname, {silent: true});
-  hexo.config.sitemap = {
-    path: 'sitemap.xml'
-  };
   const Post = hexo.model('Post');
-  const generator = require('../lib/generator').bind(hexo);
-  const sitemapTmpl = require('../lib/template')(hexo.config);
   let posts = {};
+  let locals = {};
+
+  before(() => {
+    return hexo.init();
+  });
+
+  it('should generate', () => {
+    Post.insert([
+      {source: 'foo', slug: 'foo', updated: 1e8},
+      {source: 'bar', slug: 'bar', updated: 1e8 + 1},
+      {source: 'baz', slug: 'baz', updated: 1e8 - 1}
+    ]).then(data => {
+      posts = data.sort((a, b) => b.updated - a.updated);
+      locals = hexo.locals.toObject();
+
+      const sitemapTmpl = require('../lib/template')(ctx.config);
+      const result = generator(locals);
+
+      result.path.should.eql('sitemap.xml');
+      result.data.should.eql(sitemapTmpl.render({
+        config: ctx.config,
+        posts: posts
+      }));
+    });
+  });
+
+  it('should sort in descending order', () => {
+    const result = generator(locals);
+
+    const $ = cheerio.load(result.data);
+
+    $('url').each((index, element) => {
+      $(element).children('loc').text().should.eql(posts[index].permalink);
+      $(element).children('lastmod').text().should.eql(posts[index].updated.toISOString());
+    });
+  });
+});
+
+describe('skip_render', () => {
+  const hexo = new Hexo(__dirname, {silent: true});
+  const Post = hexo.model('Post');
   let locals = {};
 
   before(() => {
@@ -22,30 +69,12 @@ describe('Sitemap generator', () => {
         {source: 'bar', slug: 'bar', updated: 1e8 + 1},
         {source: 'baz', slug: 'baz', updated: 1e8 - 1}
       ]).then(data => {
-        posts = Post.sort('-updated');
         locals = hexo.locals.toObject();
       });
     });
   });
 
-  it('default', () => {
-    const result = generator(locals);
-
-    result.path.should.eql('sitemap.xml');
-    result.data.should.eql(sitemapTmpl.render({
-      config: hexo.config,
-      posts: posts.toArray()
-    }));
-
-    const $ = cheerio.load(result.data);
-
-    $('url').each((index, element) => {
-      $(element).children('loc').text().should.eql(posts.eq(index).permalink);
-      $(element).children('lastmod').text().should.eql(posts.eq(index).updated.toISOString());
-    });
-  });
-
-  describe('skip_render', () => {
+  describe('should skip file', () => {
     it('array', () => {
       hexo.config.skip_render = ['foo'];
 
@@ -65,6 +94,33 @@ describe('Sitemap generator', () => {
 
       const result = generator(locals);
       result.should.be.ok;
+    });
+  });
+});
+
+describe('IDN', () => {
+  const hexo = new Hexo(__dirname, {silent: true});
+  const Post = hexo.model('Post');
+
+  before(() => {
+    hexo.config.url = 'http://fôo.com/bár';
+    return hexo.init();
+  });
+
+  it('should encode URL properly', () => {
+    const parsedUrl = encodeURL(hexo.config.url);
+    Post.insert([
+      {source: 'foo', slug: 'foo', updated: 1e8},
+      {source: 'bar', slug: 'bar', updated: 1e8 + 1},
+      {source: 'baz', slug: 'baz', updated: 1e8 - 1}
+    ]).then(data => {
+      const result = generator(hexo.locals.toObject());
+
+      const $ = cheerio.load(result.data);
+
+      $('url').each((index, element) => {
+        $(element).children('loc').text().startsWith(parsedUrl).should.be.true;
+      });
     });
   });
 });


### PR DESCRIPTION
This PR is an alternative to #68 which involves a major rewrite of the unit test in order to resolve https://github.com/hexojs/hexo-generator-sitemap/pull/68#discussion_r321993190 https://github.com/hexojs/hexo-generator-sitemap/pull/66/files#r314965773

While this approach passes `IDN` tests, it fails `skip_render`. The unit test may need to be rewrite from scratch.

Both this PR and #68 have a **working** code that **do resolve** the initial issue, which is proper handling of url with IDN; however both PRs are currently stuck behind deficient unit test.