### PR TITLE
feat: insert rel-sitemap tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,10 +23,12 @@ You can configure this plugin in `_config.yml`.
 sitemap:
     path: sitemap.xml
     template: ./sitemap_template.xml
+    rel: true
 ```
 
 - **path** - Sitemap path. (Default: sitemap.xml)
 - **template** - Custom template path. This file will be used to generate sitemap.xml (See [default template](/sitemap.xml))
+- **rel** - Add [`rel-sitemap`](http://microformats.org/wiki/rel-sitemap) to the site's header. (Default: `true`)
 
 ## Excluding Posts
 

--- a/README.md
+++ b/README.md
@@ -23,12 +23,12 @@ You can configure this plugin in `_config.yml`.
 sitemap:
     path: sitemap.xml
     template: ./sitemap_template.xml
-    rel: true
+    rel: false
 ```
 
 - **path** - Sitemap path. (Default: sitemap.xml)
 - **template** - Custom template path. This file will be used to generate sitemap.xml (See [default template](/sitemap.xml))
-- **rel** - Add [`rel-sitemap`](http://microformats.org/wiki/rel-sitemap) to the site's header. (Default: `true`)
+- **rel** - Add [`rel-sitemap`](http://microformats.org/wiki/rel-sitemap) to the site's header. (Default: `false`)
 
 ## Excluding Posts
 

--- a/index.js
+++ b/index.js
@@ -14,6 +14,6 @@ if (!extname(config.path)) {
 
 hexo.extend.generator.register('sitemap', require('./lib/generator'));
 
-if (config.sitemap.rel === true) {
+if (config.rel === true) {
   hexo.extend.filter.register('after_render:html', require('./lib/rel'));
 }

--- a/index.js
+++ b/index.js
@@ -4,7 +4,8 @@
 const { extname } = require('path');
 
 const config = hexo.config.sitemap = Object.assign({
-  path: 'sitemap.xml'
+  path: 'sitemap.xml',
+  rel: true
 }, hexo.config.sitemap);
 
 if (!extname(config.path)) {
@@ -12,3 +13,7 @@ if (!extname(config.path)) {
 }
 
 hexo.extend.generator.register('sitemap', require('./lib/generator'));
+
+if (config.sitemap.rel === true) {
+  hexo.extend.filter.register('after_render:html', require('./lib/rel'));
+}

--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ const { extname } = require('path');
 
 const config = hexo.config.sitemap = Object.assign({
   path: 'sitemap.xml',
-  rel: true
+  rel: false
 }, hexo.config.sitemap);
 
 if (!extname(config.path)) {

--- a/lib/rel.js
+++ b/lib/rel.js
@@ -1,0 +1,15 @@
+'use strict';
+
+const { url_for } = require('hexo-util');
+
+function relSitemapInject(data) {
+  const { path, rel } = this.config.sitemap;
+
+  if (!rel || data.match(/rel=['|"]?sitemap['|"]?/i)) return;
+
+  const relSitemap = `<link rel="sitemap" type="application/xml" title="Sitemap" href="${url_for.call(this, path)}" >`;
+
+  return data.replace(/<head>(?!<\/head>).+?<\/head>/, (str) => str.replace('</head>', `${relSitemap}</head>`));
+}
+
+module.exports = relSitemapInject;

--- a/lib/rel.js
+++ b/lib/rel.js
@@ -7,7 +7,7 @@ function relSitemapInject(data) {
 
   if (!rel || data.match(/rel=['|"]?sitemap['|"]?/i)) return;
 
-  const relSitemap = `<link rel="sitemap" type="application/xml" title="Sitemap" href="${url_for.call(this, path)}" >`;
+  const relSitemap = `<link rel="sitemap" type="application/xml" title="Sitemap" href="${url_for.call(this, path)}">`;
 
   return data.replace(/<head>(?!<\/head>).+?<\/head>/, (str) => str.replace('</head>', `${relSitemap}</head>`));
 }

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   ],
   "license": "MIT",
   "dependencies": {
+    "hexo-util": "^1.3.0",
     "micromatch": "^4.0.2",
     "nunjucks": "^3.1.6"
   },

--- a/test/index.js
+++ b/test/index.js
@@ -71,15 +71,15 @@ describe('Sitemap generator', () => {
 
 describe('Rel-Sitemap', () => {
   const hexo = new Hexo();
-  const autoDiscovery = require('../lib/rel').bind(hexo);
   hexo.config.sitemap = {
     path: 'sitemap.xml',
     rel: true
   };
+  const relSitemap = require('../lib/rel').bind(hexo);
 
   it('default', () => {
     const content = '<head><link></head>';
-    const result = autoDiscovery(content);
+    const result = relSitemap(content);
 
     const $ = cheerio.load(result);
     $('link[rel="sitemap"]').length.should.eql(1);
@@ -91,7 +91,7 @@ describe('Rel-Sitemap', () => {
   it('prepend root', () => {
     hexo.config.root = '/root/';
     const content = '<head><link></head>';
-    const result = autoDiscovery(content);
+    const result = relSitemap(content);
 
     const $ = cheerio.load(result);
     $('link[rel="sitemap"]').attr('href').should.eql(hexo.config.root + hexo.config.sitemap.path);
@@ -100,20 +100,20 @@ describe('Rel-Sitemap', () => {
     hexo.config.root = '/';
   });
 
-  it('disable autodiscovery', () => {
-    hexo.config.sitemap.autodiscovery = false;
+  it('disable', () => {
+    hexo.config.sitemap.rel = false;
     const content = '<head><link></head>';
-    const result = autoDiscovery(content);
+    const result = relSitemap(content);
 
     const resultType = typeof result;
     resultType.should.eql('undefined');
-    hexo.config.sitemap.autodiscovery = true;
+    hexo.config.sitemap.rel = true;
   });
 
   it('no duplicate tag', () => {
     const content = '<head><link>'
       + '<link rel="sitemap" type="application/xml" title="Sitemap" href="/sitemap.xml"></head>';
-    const result = autoDiscovery(content);
+    const result = relSitemap(content);
 
     const resultType = typeof result;
     resultType.should.eql('undefined');
@@ -123,7 +123,7 @@ describe('Rel-Sitemap', () => {
     const content = '<head></head>'
       + '<head><link></head>'
       + '<head></head>';
-    const result = autoDiscovery(content);
+    const result = relSitemap(content);
 
     const $ = cheerio.load(result);
     $('link[rel="sitemap"]').length.should.eql(1);
@@ -138,7 +138,7 @@ describe('Rel-Sitemap', () => {
     const content = '<head></head>'
       + '<head><link></head>'
       + '<head><link></head>';
-    const result = autoDiscovery(content);
+    const result = relSitemap(content);
 
     const $ = cheerio.load(result);
     $('link[rel="sitemap"]').length.should.eql(1);

--- a/test/index.js
+++ b/test/index.js
@@ -68,3 +68,84 @@ describe('Sitemap generator', () => {
     });
   });
 });
+
+describe('Rel-Sitemap', () => {
+  const hexo = new Hexo();
+  const autoDiscovery = require('../lib/rel').bind(hexo);
+  hexo.config.sitemap = {
+    path: 'sitemap.xml',
+    rel: true
+  };
+
+  it('default', () => {
+    const content = '<head><link></head>';
+    const result = autoDiscovery(content);
+
+    const $ = cheerio.load(result);
+    $('link[rel="sitemap"]').length.should.eql(1);
+    $('link[rel="sitemap"]').attr('href').should.eql(hexo.config.root + hexo.config.sitemap.path);
+
+    result.should.eql('<head><link><link rel="sitemap" type="application/xml" title="Sitemap" href="/sitemap.xml"></head>');
+  });
+
+  it('prepend root', () => {
+    hexo.config.root = '/root/';
+    const content = '<head><link></head>';
+    const result = autoDiscovery(content);
+
+    const $ = cheerio.load(result);
+    $('link[rel="sitemap"]').attr('href').should.eql(hexo.config.root + hexo.config.sitemap.path);
+
+    result.should.eql('<head><link><link rel="sitemap" type="application/xml" title="Sitemap" href="/root/sitemap.xml"></head>');
+    hexo.config.root = '/';
+  });
+
+  it('disable autodiscovery', () => {
+    hexo.config.sitemap.autodiscovery = false;
+    const content = '<head><link></head>';
+    const result = autoDiscovery(content);
+
+    const resultType = typeof result;
+    resultType.should.eql('undefined');
+    hexo.config.sitemap.autodiscovery = true;
+  });
+
+  it('no duplicate tag', () => {
+    const content = '<head><link>'
+      + '<link rel="sitemap" type="application/xml" title="Sitemap" href="/sitemap.xml"></head>';
+    const result = autoDiscovery(content);
+
+    const resultType = typeof result;
+    resultType.should.eql('undefined');
+  });
+
+  it('ignore empty head tag', () => {
+    const content = '<head></head>'
+      + '<head><link></head>'
+      + '<head></head>';
+    const result = autoDiscovery(content);
+
+    const $ = cheerio.load(result);
+    $('link[rel="sitemap"]').length.should.eql(1);
+
+    const expected = '<head></head>'
+    + '<head><link><link rel="sitemap" type="application/xml" title="Sitemap" href="/sitemap.xml"></head>'
+    + '<head></head>';
+    result.should.eql(expected);
+  });
+
+  it('apply to first non-empty head tag only', () => {
+    const content = '<head></head>'
+      + '<head><link></head>'
+      + '<head><link></head>';
+    const result = autoDiscovery(content);
+
+    const $ = cheerio.load(result);
+    $('link[rel="sitemap"]').length.should.eql(1);
+
+    const expected = '<head></head>'
+    + '<head><link><link rel="sitemap" type="application/xml" title="Sitemap" href="/sitemap.xml"></head>'
+    + '<head><link></head>';
+    result.should.eql(expected);
+  });
+});


### PR DESCRIPTION
[`rel-sitemap`](http://microformats.org/wiki/rel-sitemap) is a [proposed extension](http://microformats.org/wiki/existing-rel-values#HTML5_link_type_extensions) to `<link>`.

ref: http://microformats.org/wiki/rel-sitemap
credit: [meta_generator.js](https://github.com/hexojs/hexo/blob/master/lib/plugins/filter/meta_generator.js)