### PR TITLE
fix: Url is encoded twice

### DIFF
--- a/lib/template.js
+++ b/lib/template.js
@@ -13,6 +13,10 @@ module.exports = function(config) {
     watch: false
   });
 
+  env.addFilter('uriencode', str => {
+    return encodeURI(decodeURI(str));
+  });
+
   const sitemapSrc = config.sitemap.template || join(__dirname, '../sitemap.xml');
   sitemapTmpl = nunjucks.compile(readFileSync(sitemapSrc, 'utf8'), env);
 

--- a/lib/template.js
+++ b/lib/template.js
@@ -13,10 +13,6 @@ module.exports = function(config) {
     watch: false
   });
 
-  env.addFilter('uriencode', str => {
-    return encodeURI(str);
-  });
-
   const sitemapSrc = config.sitemap.template || join(__dirname, '../sitemap.xml');
   sitemapTmpl = nunjucks.compile(readFileSync(sitemapSrc, 'utf8'), env);
 

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -2,7 +2,7 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   {% for post in posts %}
   <url>
-    <loc>{{ post.permalink }}</loc>
+    <loc>{{ post.permalink | uriencode }}</loc>
     {% if post.updated %}
     <lastmod>{{ post.updated.toISOString() }}</lastmod>
     {% elif post.date %}

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -2,7 +2,7 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   {% for post in posts %}
   <url>
-    <loc>{{ post.permalink | uriencode }}</loc>
+    <loc>{{ post.permalink }}</loc>
     {% if post.updated %}
     <lastmod>{{ post.updated.toISOString() }}</lastmod>
     {% elif post.date %}


### PR DESCRIPTION
The generated link is encoded twice,  
which will cause the search engine to fail to parse links with special symbols or non-English.

![image](https://user-images.githubusercontent.com/42126168/67154415-d343ec80-f32e-11e9-931b-09b9778a72aa.png)
![image](https://user-images.githubusercontent.com/42126168/67154420-f53d6f00-f32e-11e9-8b16-e6f1c6d7bac0.png)
