### PR TITLE
fix: skip generate if no posts

### DIFF
--- a/lib/generator.js
+++ b/lib/generator.js
@@ -24,6 +24,11 @@ module.exports = function(locals) {
       return b.updated - a.updated;
     });
 
+  if (posts.length <= 0) {
+    config.sitemap.rel = false;
+    return;
+  }
+
   const xml = template(config).render({
     config,
     posts

--- a/test/index.js
+++ b/test/index.js
@@ -79,6 +79,22 @@ describe('Sitemap generator', () => {
   });
 });
 
+it('No posts', () => {
+  const hexo = new Hexo(__dirname, { silent: true });
+  hexo.config.sitemap = {
+    path: 'sitemap.xml'
+  };
+  const Post = hexo.model('Post');
+  const generator = require('../lib/generator').bind(hexo);
+
+  return Post.insert([]).then(data => {
+    const locals = hexo.locals.toObject();
+    const result = typeof generator(locals);
+
+    result.should.eql('undefined');
+  });
+});
+
 describe('Rel-Sitemap', () => {
   const hexo = new Hexo();
   hexo.config.sitemap = {


### PR DESCRIPTION
replicated from https://github.com/hexojs/hexo-generator-feed/pull/107

different from hexo-generator-feed, this only skip when there no posts _and_ pages.