### PR TITLE
fix: stricter type checking on skip_render

### DIFF
--- a/lib/generator.js
+++ b/lib/generator.js
@@ -12,8 +12,10 @@ module.exports = function(locals) {
 
   if (Array.isArray(config.skip_render)) {
     skipRenderList.push(...config.skip_render);
-  } else if (config.skip_render !== null) {
-    skipRenderList.push(config.skip_render);
+  } else if (typeof config.skip_render === 'string') {
+    if (config.skip_render.length > 0) {
+      skipRenderList.push(config.skip_render);
+    }
   }
 
   const posts = [].concat(locals.posts.toArray(), locals.pages.toArray())

--- a/test/index.js
+++ b/test/index.js
@@ -70,6 +70,13 @@ describe('Sitemap generator', () => {
       result.data.should.not.contain('bar');
     });
 
+    it('invalid type', () => {
+      hexo.config.skip_render = { foo: 'bar' };
+
+      const result = generator(locals);
+      result.should.be.ok;
+    });
+
     it('off', () => {
       hexo.config.skip_render = null;
 


### PR DESCRIPTION
micromatch only accepts a string or an array of string elements, this PR ensure `skip_render` is of valid type.