### PR TITLE
style: no-multi-assign

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,10 +3,12 @@
 
 const { extname } = require('path');
 
-const config = hexo.config.sitemap = Object.assign({
+hexo.config.sitemap = Object.assign({
   path: 'sitemap.xml',
   rel: false
 }, hexo.config.sitemap);
+
+const config = hexo.config.sitemap;
 
 if (!extname(config.path)) {
   config.path += '.xml';


### PR DESCRIPTION
eslint-config-hexo is going to enforce [no-multi-assign](https://github.com/hexojs/eslint-config-hexo/pull/22/files#diff-139d26542d80f293e0b4ff01913d24ccR88).