### PR TITLE
Provide a more reasonable default value for sitemap

### DIFF
--- a/sitemap.xml
+++ b/sitemap.xml
@@ -8,6 +8,8 @@
     {% elif post.date %}
     <lastmod>{{ post.date | formatDate }}</lastmod>
     {% endif %}
+    <changefreq>monthly</changefreq>
+    <priority>0.6</priority>
   </url>
   {% endfor %}
 
@@ -22,8 +24,8 @@
   <url>
     <loc>{{ tag.permalink | uriencode }}</loc>
     <lastmod>{{ sNow | formatDate }}</lastmod>
-    <changefreq>daily</changefreq>
-    <priority>0.6</priority>
+    <changefreq>weekly</changefreq>
+    <priority>0.2</priority>
   </url>
   {% endfor %}
 
@@ -31,8 +33,8 @@
   <url>
     <loc>{{ cat.permalink | uriencode }}</loc>
     <lastmod>{{ sNow | formatDate }}</lastmod>
-    <changefreq>daily</changefreq>
-    <priority>0.6</priority>
+    <changefreq>weekly</changefreq>
+    <priority>0.2</priority>
   </url>
   {% endfor %}
 </urlset>


### PR DESCRIPTION
As mentioned in the sitemap protocol v0.9 spec, if the `priority` field is missing,the default value is 0.5.
In the default sitemap template, all posts have 0.5 priority effectively, and the tag and category links have 0.6 priority.
which may cause search engines (although [Google ignores it](https://developers.google.com/search/docs/advanced/sitemaps/build-sitemap#xml)) to give tag/category links higher ranking than post links.

While users can override the default template,
this MR gives lower priority to tag/category links and also gives less aggressive `changefreq` settings.
IMO this should be better for users who rely on the default configuration. :D

References:

- [sitemaps.org - Protocol](https://www.sitemaps.org/protocol.html)